### PR TITLE
Rescue Uphold invalid_grant error to clear uphold_code

### DIFF
--- a/app/jobs/exchange_uphold_code_for_access_token_job.rb
+++ b/app/jobs/exchange_uphold_code_for_access_token_job.rb
@@ -7,7 +7,6 @@ class ExchangeUpholdCodeForAccessTokenJob < ApplicationJob
         publisher: publisher
     ).perform
 
-    # ToDo: UpholdRequestAccessParameters could raise exceptions which could be used to clear the code
     if parameters
       publisher.uphold_access_parameters = parameters
       # The code acquired from https://uphold.com/authorize is only good for one request and times out in 5 minutes
@@ -15,5 +14,9 @@ class ExchangeUpholdCodeForAccessTokenJob < ApplicationJob
       publisher.uphold_code = nil
       publisher.save!
     end
+
+  rescue UpholdRequestAccessParameters::InvalidGrantError => e
+    publisher.uphold_code = nil
+    publisher.save!
   end
 end

--- a/test/jobs/exchange_uphold_code_for_access_token_job_test.rb
+++ b/test/jobs/exchange_uphold_code_for_access_token_job_test.rb
@@ -1,7 +1,75 @@
 require 'test_helper'
 
 class ExchangeUpholdCodeForAccessTokenJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "sets uphold_access_parameters on success" do
+    begin
+      init_api_uphold_offline_succeeds = Rails.application.secrets[:api_uphold_offline_succeeds]
+      # init_api_uphold_offline_fails_bad_code = Rails.application.secrets[:api_uphold_offline_fails_bad_code]
+      Rails.application.secrets[:api_uphold_offline_succeeds] = true
+      # Rails.application.secrets[:api_uphold_offline_fails_bad_code] = true
+
+      publisher = publishers(:verified)
+      publisher.uphold_code = "foo"
+      publisher.uphold_access_parameters = nil
+      publisher.save!
+
+      ExchangeUpholdCodeForAccessTokenJob.perform_now(brave_publisher_id: publisher.id)
+      publisher.reload
+
+      assert_nil publisher.uphold_code
+      refute_nil publisher.uphold_access_parameters
+
+    ensure
+      Rails.application.secrets[:api_uphold_offline_succeeds] = init_api_uphold_offline_succeeds
+      # Rails.application.secrets[:api_uphold_offline_fails_bad_code] = init_api_uphold_offline_fails_bad_code
+    end
+  end
+
+  test "clears uphold_code on invalid_grant" do
+    begin
+      init_api_uphold_offline_succeeds = Rails.application.secrets[:api_uphold_offline_succeeds]
+      init_api_uphold_offline_fails_bad_code = Rails.application.secrets[:api_uphold_offline_fails_bad_code]
+      Rails.application.secrets[:api_uphold_offline_succeeds] = false
+      Rails.application.secrets[:api_uphold_offline_fails_bad_code] = true
+
+      publisher = publishers(:verified)
+      publisher.uphold_code = "foo"
+      publisher.uphold_access_parameters = nil
+      publisher.save!
+
+      ExchangeUpholdCodeForAccessTokenJob.perform_now(brave_publisher_id: publisher.id)
+      publisher.reload
+
+      assert_nil publisher.uphold_code
+      assert_nil publisher.uphold_access_parameters
+
+    ensure
+      Rails.application.secrets[:api_uphold_offline_succeeds] = init_api_uphold_offline_succeeds
+      Rails.application.secrets[:api_uphold_offline_fails_bad_code] = init_api_uphold_offline_fails_bad_code
+    end
+  end
+
+  test "preserves uphold_code on other errors" do
+    begin
+      init_api_uphold_offline_succeeds = Rails.application.secrets[:api_uphold_offline_succeeds]
+      init_api_uphold_offline_fails_bad_code = Rails.application.secrets[:api_uphold_offline_fails_bad_code]
+      Rails.application.secrets[:api_uphold_offline_succeeds] = false
+      Rails.application.secrets[:api_uphold_offline_fails_bad_code] = false
+
+      publisher = publishers(:verified)
+      publisher.uphold_code = "foo"
+      publisher.uphold_access_parameters = nil
+      publisher.save!
+
+      ExchangeUpholdCodeForAccessTokenJob.perform_now(brave_publisher_id: publisher.id)
+      publisher.reload
+
+      refute_nil publisher.uphold_code
+      assert_nil publisher.uphold_access_parameters
+
+    ensure
+      Rails.application.secrets[:api_uphold_offline_succeeds] = init_api_uphold_offline_succeeds
+      Rails.application.secrets[:api_uphold_offline_fails_bad_code] = init_api_uphold_offline_fails_bad_code
+    end
+  end
 end


### PR DESCRIPTION
Handles the special Faraday::ClientError representing the invalid_grant case where the code is invalid (timeout or already used).
Clears the code when detected.

On other Uphold connection errors the code is preserved so the code exchange can be tried again.
Note: relying on Uphold rejecting in invalid code in the future to clear the code.