### PR TITLE
Channel init process

### DIFF
--- a/app/controllers/publishers/omniauth_callbacks_controller.rb
+++ b/app/controllers/publishers/omniauth_callbacks_controller.rb
@@ -18,6 +18,7 @@ module Publishers
         publisher.auth_provider = oauth_response.provider
         publisher.auth_user_id = oauth_response.uid
         publisher.auth_name = oauth_response.dig('info', 'name')
+        publisher.name ||= publisher.auth_name
         publisher.auth_email = oauth_response.dig('info', 'email')
 
         publisher.verified = true

--- a/app/services/publisher_channel_setter.rb
+++ b/app/services/publisher_channel_setter.rb
@@ -12,13 +12,13 @@ class PublisherChannelSetter < BaseApiClient
     payload = {
       "authorizer" => {
         "owner" => "oauth#google:#{publisher.auth_user_id}",
-        "ownerEmail" => publisher.auth_email,
-        "ownerName" => publisher.auth_name
+        "ownerEmail" => publisher.auth_email.to_s,
+        "ownerName" => publisher.auth_name.to_s
       },
       "contactInfo" => {
-        "name" => publisher.name,
-        "phone" => publisher.phone_normalized,
-        "email" => publisher.email
+        "name" => publisher.name.to_s,
+        "phone" => publisher.phone_normalized.to_s,
+        "email" => publisher.email.to_s
       },
       "providers" => [
         {
@@ -29,7 +29,7 @@ class PublisherChannelSetter < BaseApiClient
     }
 
     # This raises when response is not 2xx.
-    response = connection.put do |request|
+    response = connection.post do |request|
       request.body = payload.to_json
       request.headers["Authorization"] = api_authorization_header
       request.headers["Content-Type"] = "application/json"


### PR DESCRIPTION
Initialize the contact name with the channel if it's not present
Fix post call to eyeshade /v1/owners

Still will fail because eyeshade has the phone number as a required field